### PR TITLE
FileCell should return the file's url

### DIFF
--- a/src/resources/js/components/FileCell.vue
+++ b/src/resources/js/components/FileCell.vue
@@ -43,7 +43,7 @@ export default {
                     source: this.file.source,
                     size: this.file.size,
                     type: this.file.type,
-                    url: this.url,
+                    url: this.file.url,
                 });
                 window.close();
             }else {


### PR DESCRIPTION
- Return this.file.url within FileCell instead of this.url. Right now this.url returns undefined, so when we use the window.opener we can't retrieve the file's URL