### PR TITLE
Feature/ela 3800 fileman permission issue

### DIFF
--- a/src/Http/Controllers/FileController.php
+++ b/src/Http/Controllers/FileController.php
@@ -10,6 +10,7 @@ use DcodeGroup\Fileman\Services\FolderService;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Support\Facades\Log;
 
 class FileController extends BaseController
 {
@@ -42,11 +43,15 @@ class FileController extends BaseController
 
     public function store(FileRequest $request, Folder $parent): RedirectResponse
     {
-        FileService::newFile(
-            $parent,
-            $request->file('file'),
-            $request->input('name')
-        );
+        try{
+            FileService::newFile(
+                $parent,
+                $request->file('file'),
+                $request->input('name')
+            );
+        }catch (\Exception $exception){
+            Log::error($exception->getMessage());
+        }
 
         return redirect()
             ->route(config('fileman.route_name').'.folder.index', $parent->id);

--- a/src/Http/Controllers/FileController.php
+++ b/src/Http/Controllers/FileController.php
@@ -43,13 +43,13 @@ class FileController extends BaseController
 
     public function store(FileRequest $request, Folder $parent): RedirectResponse
     {
-        try{
+        try {
             FileService::newFile(
                 $parent,
                 $request->file('file'),
                 $request->input('name')
             );
-        }catch (\Exception $exception){
+        } catch (\Exception $exception) {
             Log::error($exception->getMessage());
         }
 

--- a/src/Services/FileService.php
+++ b/src/Services/FileService.php
@@ -15,7 +15,7 @@ class FileService
     {
         $path = 'fileman';
         $name = $name ?: $file->getClientOriginalName();
-        $filename = self::getSeoFriendlyName($name,$parent);
+        $filename = self::getSeoFriendlyName($name, $parent);
 
         if (count($parent->getPath()) > 1) {
             $path = $path.'/'.$parent->getFolderPath();
@@ -130,14 +130,17 @@ class FileService
         $name = strtolower(trim($name)); // Convert to lowercase and trim whitespace
         $name = preg_replace('/\s+/', '-', $name); // Replace spaces with hyphens
         $name = preg_replace('/-+/', '-', $name); // Remove duplicate hyphens
-        return self::getUniqueName($name,$folder,$extension);
+
+        return self::getUniqueName($name, $folder, $extension);
     }
 
-    public static function getUniqueName($name, $folder, $extension): string{
-        if(File::query()->where('folder_id',$folder->id)
-            ->where('name',$name.'.'.$extension)->exists()){
-            return self::getUniqueName($name."_copy", $folder, $extension);
+    public static function getUniqueName($name, $folder, $extension): string
+    {
+        if (File::query()->where('folder_id', $folder->id)
+            ->where('name', $name.'.'.$extension)->exists()) {
+            return self::getUniqueName($name.'_copy', $folder, $extension);
         }
+
         return $name.'.'.$extension;
     }
 }

--- a/src/Services/FileService.php
+++ b/src/Services/FileService.php
@@ -15,7 +15,7 @@ class FileService
     {
         $path = 'fileman';
         $name = $name ?: $file->getClientOriginalName();
-        $filename = self::getSeoFriendlyName($name);
+        $filename = self::getSeoFriendlyName($name,$parent);
 
         if (count($parent->getPath()) > 1) {
             $path = $path.'/'.$parent->getFolderPath();
@@ -121,7 +121,7 @@ class FileService
             ->get();
     }
 
-    public static function getSeoFriendlyName($fileName): string
+    public static function getSeoFriendlyName($fileName, Folder $folder): string
     {
         // extension
         $extension = pathinfo($fileName, PATHINFO_EXTENSION);
@@ -130,6 +130,14 @@ class FileService
         $name = strtolower(trim($name)); // Convert to lowercase and trim whitespace
         $name = preg_replace('/\s+/', '-', $name); // Replace spaces with hyphens
         $name = preg_replace('/-+/', '-', $name); // Remove duplicate hyphens
-        return uniqid().'-'.$name.'.'.$extension;
+        return self::getUniqueName($name,$folder,$extension);
+    }
+
+    public static function getUniqueName($name, $folder, $extension): string{
+        if(File::query()->where('folder_id',$folder->id)
+            ->where('name',$name.'.'.$extension)->exists()){
+            return self::getUniqueName($name."_copy", $folder, $extension);
+        }
+        return $name.'.'.$extension;
     }
 }

--- a/src/Services/FilemanService.php
+++ b/src/Services/FilemanService.php
@@ -3,42 +3,41 @@
 namespace DcodeGroup\Fileman\Services;
 
 use DcodeGroup\Fileman\Models\Folder;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 class FilemanService
 {
-    public static function import(): void
+    public static function import($parentFolder=null,$folderName = null): void
     {
-        $folderPaths = FileService::getDisk()->allDirectories();
-
-        $root = Folder::firstOrCreate([
-            'parent_id' => null,
-            'name' => '_root',
-        ]);
-
+        $folderPaths = FileService::getDisk()->directories($folderName ?? '');
+        if($parentFolder == null){
+            $parent =  Folder::firstOrCreate([
+                'parent_id' => null,
+            ],[
+                'parent_id' => null,
+                'name' => 'Root',
+            ]);
+        }else{
+            $parent = $parentFolder;
+        }
         foreach ($folderPaths as $folderPath) {
             $folderNames = explode('/', $folderPath);
-
             $folder = Folder::firstOrCreate([
-                'parent_id' => $root->id,
-                'name' => $folderNames[0],
+                'parent_id' => $parent->id,
+                'name' => $folderNames[count($folderNames) - 1],
             ]);
-
-            foreach ($folderNames as $index => $folderName) {
-                if ($index !== 0) {
-                    $folder = Folder::firstOrCreate([
-                        'parent_id' => $folder->id,
-                        'name' => $folderName,
-                    ]);
-                }
-
-                $filePaths = FileService::getDisk()->files($folderPath);
-
-                foreach ($filePaths as $filePath) {
-                    // @phpstan-ignore-next-line
-                    FileService::newFileFromS3($folder, Storage::getMetaData($filePath));
-                }
-            }
+            self::import($folder,$folderPath);
+        }
+        $filePaths = FileService::getDisk()->files($folderName?? '');
+        foreach ($filePaths as $filePath) {
+            // @phpstan-ignore-next-line
+            FileService::newFileFromS3($parent, [
+                'filename' => basename($filePath),
+                'path' => $filePath,
+                'mimetype' => Storage::disk('s3')->mimeType($filePath),
+                'size' => Storage::disk('s3')->size($filePath),
+            ]);
         }
     }
 }

--- a/src/Services/FilemanService.php
+++ b/src/Services/FilemanService.php
@@ -3,22 +3,21 @@
 namespace DcodeGroup\Fileman\Services;
 
 use DcodeGroup\Fileman\Models\Folder;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 class FilemanService
 {
-    public static function import($parentFolder=null,$folderName = null): void
+    public static function import($parentFolder = null, $folderName = null): void
     {
         $folderPaths = FileService::getDisk()->directories($folderName ?? '');
-        if($parentFolder == null){
-            $parent =  Folder::firstOrCreate([
+        if ($parentFolder == null) {
+            $parent = Folder::firstOrCreate([
                 'parent_id' => null,
-            ],[
+            ], [
                 'parent_id' => null,
                 'name' => 'Root',
             ]);
-        }else{
+        } else {
             $parent = $parentFolder;
         }
         foreach ($folderPaths as $folderPath) {
@@ -27,9 +26,9 @@ class FilemanService
                 'parent_id' => $parent->id,
                 'name' => $folderNames[count($folderNames) - 1],
             ]);
-            self::import($folder,$folderPath);
+            self::import($folder, $folderPath);
         }
-        $filePaths = FileService::getDisk()->files($folderName?? '');
+        $filePaths = FileService::getDisk()->files($folderName ?? '');
         foreach ($filePaths as $filePath) {
             // @phpstan-ignore-next-line
             FileService::newFileFromS3($parent, [

--- a/src/resources/js/components/FileCell.vue
+++ b/src/resources/js/components/FileCell.vue
@@ -4,7 +4,7 @@
        :data-url="file.url"
 
     >
-        <img :src="file.previewUrl" class="thumbnail !h-4/5 object-contain"  :alt="file.name" v-if="file.is_image" @click="showFileDetail">
+        <img :src="file.previewUrl" class="thumbnail !h-4/5 object-contain break-all"  :alt="file.name" v-if="file.is_image" @click="showFileDetail">
         <div class="flex flex-col items-center justify-center h-full w-full relative" @click="showFileDetail" v-else>
             <div class="h-20 w-20 relative">
                 <file-page class="h-20 w-16 ml-auto"></file-page>

--- a/src/resources/js/components/PopupLayout.vue
+++ b/src/resources/js/components/PopupLayout.vue
@@ -35,10 +35,5 @@ export default {
             folderName: ''
         };
     },
-    methods:{
-        closePopup() {
-            console.log('closepopup')
-        }
-    }
 };
 </script>

--- a/src/resources/js/components/PopupLayout.vue
+++ b/src/resources/js/components/PopupLayout.vue
@@ -5,7 +5,7 @@
                 <h3 class="text-lg font-semibold text-gray-900">
                     <slot name="title">Add Folder</slot>
                 </h3>
-                <x-close class="w-6 h-6 path--stroke-gray-400 cursor-pointer" @click="$emit('close')"></x-close>
+                <x-close class="w-6 h-6 path--stroke-gray-400 cursor-pointer z-10" @click="$emit('close')"></x-close>
             </div>
             <div class="text-sm font-normal text-gray-600 mt-3">
                 <slot name="subtitle"></slot>
@@ -35,5 +35,10 @@ export default {
             folderName: ''
         };
     },
+    methods:{
+        closePopup() {
+            console.log('closepopup')
+        }
+    }
 };
 </script>

--- a/src/resources/js/components/UploadFile.vue
+++ b/src/resources/js/components/UploadFile.vue
@@ -20,7 +20,7 @@
 
             </div>
             <div v-else class="mt-auto">
-                <p>File Selected: {{ file.name }}</p>
+                <p class="break-all">File Selected: {{ file.name }}</p>
                 <p>File Size : {{formatBytes(file.size)}} </p>
 
             </div>
@@ -86,6 +86,7 @@ export default {
             if (files.length > 0) {
                 this.file = files[0];
             }
+            this.uploadFile();
         },
         onFileSelect(event) {
             const files = event.target.files;

--- a/src/resources/views/layouts/page.blade.php
+++ b/src/resources/views/layouts/page.blade.php
@@ -1,7 +1,7 @@
 @component('fileman::layouts.components.html')
     @slot('body')
         <div class="page bg-white max-h-screen min-w-[90rem]">
-            <div class="w-80 border border-gray-200">
+            <div class="w-80 border border-gray-200 overflow-scroll">
                 @include('fileman::components.side.header')
                 <div class="directory">
                     @include('fileman::components.side.directory', [


### PR DESCRIPTION
## Kanopi

[https://kanopi.live/app/ticket/52457/edit](https://kanopi.live/app/ticket/52457/edit)

## Key Points

- Backend Changes:
    - Improved error handling in FileController by adding logging for exception cases.
    - Enhanced FileService to ensure unique filenames in folders, with a recursive fallback mechanism for duplicates.
    - Refactored FilemanService::import to streamline folder and file creation, adding better flexibility for handling folder structure.
- Frontend Changes:
    - Added UI improvements for filenames by implementing break-all class in file display components (FileCell.vue, UploadFile.vue).
    - Small enhancement in PopupLayout.vue to increase the z-index for the close button for better visibility.
    - Trigger file upload immediately after file selection in UploadFile.vue.
    
## Screenshots
name
![Screenshot 2025-04-30 at 10 46 36 am](https://github.com/user-attachments/assets/e808c92c-59ff-42f5-8798-c4d1bc50e049)

import the files from s3
![Screenshot 2025-04-30 at 10 46 55 am](https://github.com/user-attachments/assets/1d494081-35a3-47e8-ac3d-11b7321dced1)


    