### PR TITLE
feature/ELA-4850-deleted-file-access

### DIFF
--- a/src/Http/Controllers/Api/FileController.php
+++ b/src/Http/Controllers/Api/FileController.php
@@ -5,6 +5,7 @@ namespace DcodeGroup\Fileman\Http\Controllers\Api;
 use DcodeGroup\Fileman\Http\Requests\UpdateFileRequest;
 use DcodeGroup\Fileman\Models\File;
 use DcodeGroup\Fileman\Models\Folder;
+use DcodeGroup\Fileman\Services\FileService;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Routing\Controller as BaseController;
 
@@ -22,7 +23,7 @@ class FileController extends BaseController
 
     public function destroy(Folder $parent, File $file): JsonResource
     {
-        $file->delete();
+        FileService::deleteFile($file);
 
         return new JsonResource([
             'success' => true,

--- a/src/Http/Requests/UpdateFileRequest.php
+++ b/src/Http/Requests/UpdateFileRequest.php
@@ -3,6 +3,7 @@
 namespace DcodeGroup\Fileman\Http\Requests;
 
 use DcodeGroup\Fileman\Http\Rules\ValidFileName;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateFileRequest extends FormRequest
@@ -18,7 +19,7 @@ class UpdateFileRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/src/Http/Rules/ValidFileName.php
+++ b/src/Http/Rules/ValidFileName.php
@@ -5,13 +5,14 @@ namespace DcodeGroup\Fileman\Http\Rules;
 use Closure;
 use DcodeGroup\Fileman\Services\FileService;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 class ValidFileName implements ValidationRule
 {
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/src/Http/Rules/ValidFileType.php
+++ b/src/Http/Rules/ValidFileType.php
@@ -5,13 +5,14 @@ namespace DcodeGroup\Fileman\Http\Rules;
 use Closure;
 use DcodeGroup\Fileman\Services\FileService;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 class ValidFileType implements ValidationRule
 {
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/src/Services/FileService.php
+++ b/src/Services/FileService.php
@@ -143,4 +143,12 @@ class FileService
 
         return $name.'.'.$extension;
     }
+
+    public static function deleteFile(File $file)
+    {
+        if (FileService::getDisk()->exists($file->source)) {
+            FileService::getDisk()->delete($file->source);
+        }
+        $file->delete();
+    }
 }


### PR DESCRIPTION
## Kanopi
https://kanopi.live/app/ticket/61896/edit

## Key Points
- refactor(file): move file deletion logic to service layer
- Extracted file deletion logic from controller to FileService
- Added deleteFile method in FileService to handle file removal
- Updated controller to use FileService::deleteFile instead of direct model delete
- Ensured disk file is deleted before database record removal
- Maintained existing file deletion functionality while improving code organisation